### PR TITLE
🐛 fix: fix docs and code about direction type desc

### DIFF
--- a/docs/components/flexbox.md
+++ b/docs/components/flexbox.md
@@ -29,19 +29,19 @@ group: 一维布局
 
 ## API
 
-| 属性          | 说明             | 类型                                                                    | 默认值     |
-| ------------- | ---------------- | ----------------------------------------------------------------------- | ---------- |
-| horizontal    | 是否横向         | boolean                                                                 | false      |
-| direction     | 主轴方向         | `row` &#124; `row-reverse` &#124; `column` &#124; `column-reverse`      | `row`      |
-| distribution  | 内容分布         | `start` &#124; `end` &#124; `center` &#124; `between` &#124; `around`   | -          |
-| justify       | 主轴对齐方式     | `start` &#124; `end` &#124; `center` &#124; `between` &#124; `around`   | -          |
-| align         | 交叉轴对齐方式   | `start` &#124; `end` &#124; `center` &#124; `baseline` &#124; `stretch` | `stretch`  |
-| gap           | 主轴方向上的间距 | number &#124; string                                                    | 0          |
-| width         | 宽度             | number &#124; string                                                    | `auto`     |
-| height        | 高度             | number &#124; string                                                    | `auto`     |
-| padding       | 内边距           | number &#124; string &#124; [number, number?, number?, number?]         | 0          |
-| paddingInline | 内联内边距       | number &#124; string                                                    | -          |
-| paddingBlock  | 块内边距         | number &#124; string                                                    | -          |
-| flex          | flex 值          | number &#124; string                                                    | `0 1 auto` |
-| visible       | 是否显示         | boolean                                                                 | true       |
-| as            | 元素类型         | string &#124; React.ComponentType                                       | `div`      |
+| 属性          | 说明             | 类型                                                                                 | 默认值       |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------ | ------------ |
+| horizontal    | 是否横向         | boolean                                                                              | false        |
+| direction     | 主轴方向         | `vertical` &#124; `vertical-reverse` &#124; `horizontal` &#124; `horizontal-reverse` | `horizontal` |
+| distribution  | 内容分布         | `start` &#124; `end` &#124; `center` &#124; `between` &#124; `around`                | -            |
+| justify       | 主轴对齐方式     | `start` &#124; `end` &#124; `center` &#124; `between` &#124; `around`                | -            |
+| align         | 交叉轴对齐方式   | `start` &#124; `end` &#124; `center` &#124; `baseline` &#124; `stretch`              | `stretch`    |
+| gap           | 主轴方向上的间距 | number &#124; string                                                                 | 0            |
+| width         | 宽度             | number &#124; string                                                                 | `auto`       |
+| height        | 高度             | number &#124; string                                                                 | `auto`       |
+| padding       | 内边距           | number &#124; string &#124; [number, number?, number?, number?]                      | 0            |
+| paddingInline | 内联内边距       | number &#124; string                                                                 | -            |
+| paddingBlock  | 块内边距         | number &#124; string                                                                 | -            |
+| flex          | flex 值          | number &#124; string                                                                 | `0 1 auto`   |
+| visible       | 是否显示         | boolean                                                                              | true         |
+| as            | 元素类型         | string &#124; React.ComponentType                                                    | `div`        |

--- a/src/FlexBasic/index.tsx
+++ b/src/FlexBasic/index.tsx
@@ -26,9 +26,9 @@ export interface IFlexbox {
   // 基础 api
   /**
    * @title 主轴方向
-   * @enum ["row", "row-reverse", "column", "column-reverse"]
-   * @enumNames ["水平从左到右", "水平从右到左", "垂直从上到下", "垂直从下到上"]
-   * @default "row"
+   * @enum ["vertical", "vertical-reverse", "horizontal", "horizontal-reverse"]
+   * @enumNames ["垂直从上到下", "垂直从下到上","水平从左到右", "水平从右到左"]
+   * @default "horizontal"
    */
   direction?: FlexDirection;
   /**


### PR DESCRIPTION
hello boss.
I happen that when I using ‘direction’, its type equals to 'FlexDirection'. However, there is no such fields like 'row' or 'column' in 'FlexDirection'. Thus, I believe that we need to use the types related to 'FlexDirection' at this point, in order to avoid confusion.